### PR TITLE
Fix #1 fix for the torpedo weapon for the GT4500

### DIFF
--- a/src/main/java/hu/bme/mit/spaceship/GT4500.java
+++ b/src/main/java/hu/bme/mit/spaceship/GT4500.java
@@ -80,6 +80,14 @@ public class GT4500 implements SpaceShip {
         // try to fire both of the torpedo stores
         //TODO implement feature
 
+        //if the primary can be fired it fires
+        if (! primaryTorpedoStore.isEmpty()) {
+          firingSuccess = primaryTorpedoStore.fire(1);
+        }
+        //if the secondary can fire it fires
+        if (! secondaryTorpedoStore.isEmpty()) {
+          firingSuccess = secondaryTorpedoStore.fire(1);
+        }
         break;
     }
 


### PR DESCRIPTION
The torpedo weapon for the GT4500 was missing the "fire all projectiles" function. This fix implements the fhis feature.